### PR TITLE
Use _message when _rpcError is true

### DIFF
--- a/request.js
+++ b/request.js
@@ -39,7 +39,7 @@ function handleResponse(response){
 	delete requestLookup[correlationId];
 
 	if (msg && msg._rpcError) {
-		requestEntry.cb(new Error(msg.message || 'unknown error in rpc server'));
+		requestEntry.cb(new Error(msg._message || 'unknown error in rpc server'));
 	} else {
 		requestEntry.cb(null, msg);
 	}


### PR DESCRIPTION
@chevett 

`_message` is how the info is stored in the error case (see response lines 70,71) so just read it from there when handling a response.