### PR TITLE
set label on message fix

### DIFF
--- a/queue.js
+++ b/queue.js
@@ -220,7 +220,7 @@ function Queue(params){
 							const { routingKey } = msg.fields;
 							// there are potentially many matches, but we just use the first one. meh.
 							const matchedBinding = _.find(labeledBindings, b => {
-								// it is possible to apply the wrong label to an exchange if
+								// it is possible to apply the wrong label to a message if
 								// we do not specify the exchange
 								const isRightExchange = b.name === myMessage._exchange;
 								return b.isMatch && b.isMatch(routingKey) && isRightExchange;

--- a/queue.js
+++ b/queue.js
@@ -219,7 +219,12 @@ function Queue(params){
 
 							const { routingKey } = msg.fields;
 							// there are potentially many matches, but we just use the first one. meh.
-							const matchedBinding = _.find(labeledBindings, b => b.isMatch && b.isMatch(routingKey));
+							const matchedBinding = _.find(labeledBindings, b => {
+								// it is possible to apply the wrong label to an exchange if
+								// we do not specify the exchange
+								const isRightExchange = b.name === myMessage._exchange;
+								return b.isMatch && b.isMatch(routingKey) && isRightExchange;
+							});
 							if (matchedBinding) {
 								myMessage._label = matchedBinding.label;
 							}


### PR DESCRIPTION
```
const queue = new Queue({
	name: 'relay_controlled_ready',
	bindings: [
		{ label: 'batch_order_ready', name: 'relay_cron', type: 'topic', key: `#` },
		{ label: 'relay_controlled_ready_change', name: 'relay_controlled_ready_change', type: 'fanout' },
	],
	useErrorQueue: true,
});

[Jul 20 15:14:01.654PM][info][order-processor] message in auto_ready q {"producerLocationKey":"saartruck","relayControlledReady":"53","_exchange":"rela
y_controlled_ready_change","_label":"batch_order_ready"}