### PR TITLE
fix multi word wc mishandling in _patternToMatcher

### DIFF
--- a/queue.js
+++ b/queue.js
@@ -48,7 +48,13 @@ function getNoAckParam(params){
 function _patternToMatcher(pattern) {
 	if (!pattern) return _.constant(false);
 	// https://github.com/mateodelnorte/amqp-match/blob/master/index.js
-	const regexString = '^' + pattern.replace(/\*/g, '([^.]+)').replace(/#/g, '([^.]+.?)+') + '$';
+	const regexString = '^' +
+		pattern.replace(/[.]/g, '\\.') // escape dots
+			.replace(/\*/g, '([^.]+)') // single word wildcard
+			.replace(/^#\\./, '([^.]+[.])*') // multi word wildcard at start of key
+			.replace(/\\.#$/, '([.][^.]+)*') // multi word wildcard at end of key
+			.replace(/\\.#\\./g, '(([.].*[.])*|[.])') // multi word wildcard within key
+		+ '$';
 
 	return function(str) {
 		if (!str) return false;


### PR DESCRIPTION
label application currently deviates from rabbitmq routing handing on some multi-word wildcard cases:
- `#.foo` doesn't get matched on routingKey `foo`
- `foo.#` doesn't get matched on routingKey `foo`
- `foo.#.bar` doesn't get matched on routingKey `foo.bar`

I've forked and added some tests (https://github.com/nbr23/amqp-match/blob/master/test/index.js) on the source repo for this that make the issues explicit:
- before fix: https://github.com/nbr23/amqp-match/actions/runs/11579349850/job/32235332465
```
   amqp-match
    ✓ should match this.key to this.key (direct equality)
    ✓ should not match key to this.key (direct inequality)
    ✓ should match this.new.key to this.*.key (single word wildcard)
    ✓ should match this.new.key to *.new.key (beginning single word wildcard)
    ✓ should match this.new.key to this.new.* (end single word wildcard)
    1) should not match this-new.key to this.*.key (single word wildcard)
    ✓ should not match some.new.kinda.key to this.*.key (single word wildcard)
    ✓ should not match this.new.key.end to this.new.* (end single word wildcard)
    ✓ should not match start.this.new.key to *.new.key (beginning single word wildcard)
    ✓ should not match this.new.key to *.* (single word wildcards)
    ✓ should match this.key to *.* (single word wildcards)
    ✓ should match this.new.kinda.key to this.#.key (multi word wildcard)
    2) should match this.key to this.#.key (multi word wildcard with empty matching)
    ✓ should match this.kind.of.key.end to this.kind.of.# (end of key wildcard)
    3) should match this.kind.of to this.kind.of.# (end of key wildcard without end)
    ✓ should match this.kind.of.key.end to this.#.key.# (multi wildcard with end of key wildcard)
    4) should match this.kind.of.key.end to this.#.key.# (multi wildcard with end of key wildcard and no end of key)
    ✓ should not match wildcard with bad constant parts
    ✓ should match multi word wildcard at beginning of string
    5) should not match multi word wildcard at beginning of string with bad constant part
    ✓ should work on mixed keys
    ✓ should fail on bad mixed keys 1
    ✓ should fail on bad mixed keys 2
    6) should fail on bad mixed keys 3


  18 passing (16ms)
  6 failing
```
- fix: https://github.com/nbr23/amqp-match/actions/runs/11579565388/job/32236063425

I don't think it's worth adding new tests in wabbitzzz, but for testing purposes, adding these in queue.spec.js makes the issue clear:

```javascript
	it('should work with fancy wildcard labels', function(done){
		this.timeout(5000);

		var exchangeName = ezuuid();
		var message = ezuuid();

		var exchange1 = new Exchange({name: exchangeName, type: 'topic',  autoDelete: true});

		exchange1.on('ready', function(){

			var queue = new Queue({
				autoDelete: true,
				exclusive: true,
				bindings: [
					{ name: exchangeName, key: 'jimmy.#' , label: 'three' },
				],
				ready: function(){
					exchange1.publish({key:message}, { key: 'jimmy' });
				},
			});

			queue(function(msg, ack){
				if (msg.key !== message) return done('got a message I shouldnt have');

				expect(msg._label).to.be.equal('three');
				ack();
				done();
			});

		});

	});
	it('should work with fancy wildcard labels 2', function(done){
		this.timeout(5000);

		var exchangeName = ezuuid();
		var message = ezuuid();

		var exchange1 = new Exchange({name: exchangeName, type: 'topic',  autoDelete: true});

		exchange1.on('ready', function(){

			var queue = new Queue({
				autoDelete: true,
				exclusive: true,
				bindings: [
					{ name: exchangeName, key: 'jimmy.#.jim' , label: 'three' },
				],
				ready: function(){
					exchange1.publish({key:message}, { key: 'jimmy.jim' });
				},
			});

			queue(function(msg, ack){
				if (msg.key !== message) return done('got a message I shouldnt have');

				expect(msg._label).to.be.equal('three');
				ack();
				done();
			});

		});

	});
```
