### PR TITLE
allow quorum queues' error queue type override

### DIFF
--- a/queue.js
+++ b/queue.js
@@ -392,7 +392,7 @@ function Queue(connString, params){
 			}
 
 			if (isQuorumQueue) {
-				errorOptions.arguments = { ...errorOptions.arguments, 'x-queue-type': 'quorum' };
+				errorOptions.arguments = { 'x-queue-type': 'quorum', ...errorOptions.arguments };
 			}
 
 			await chan.assertQueue(errorQueueName, errorOptions);


### PR DESCRIPTION
currently we make quorum queue's error queues quorum, I want to be able to override this and have a classic (and sometimes non durable) error queue for my quorum queue